### PR TITLE
fix: sacctmgr needs int for node tres

### DIFF
--- a/modules/coact.py
+++ b/modules/coact.py
@@ -916,6 +916,8 @@ def toggle_job_blocking(point: OveragePoint, execute: bool = False) -> bool:
             logger.warning(f"Invalid node count {nodes} for {point['facility']}@{point['cluster']}, using unlimited")
             nodes = -1
 
+    nodes = math.ceil(nodes)
+
     facility_usage = FacilityNodeUsage(
         facility=point['facility'],
         cluster=point['cluster'],


### PR DESCRIPTION
would not toggle back due to float arg for tres nodes.